### PR TITLE
golangci: Disable godupl linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -164,7 +164,7 @@ linters:
     - gosec
     - interfacer
     - unconvert
-    - dupl
+    # - dupl
     # - goconst
     - gocyclo
     - gofmt


### PR DESCRIPTION
There should be a way to disable for specific package, need to check later.