### PR TITLE
Dockerfile: Use default user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,4 @@ FROM gcr.io/distroless/base:nonroot
 
 COPY --from=build-env /api/cmd/hbl/hbl /api/cmd/hbl/hbl
 
-USER nobody
-
 CMD ["/api/cmd/hbl/hbl"]


### PR DESCRIPTION
```
{"level":"fatal","ts":1616620118.9033992,"caller":"hbl/api.go:55","msg":"listen tcp 0.0.0.0:80: bind: permission denied","stacktrace":"github.com/hostinger/hbl/pkg/hbl.(*API).Start\n\t/api/pkg/hbl/api.go:55\nmain.main.func1\n\t/api/cmd/hbl/hbl.go:70"}
```
Will need to check later how to bind and route to non-default port